### PR TITLE
Dev

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -20,7 +20,7 @@ jobs:
         echo "::set-env name=CC::gcc-8"
         echo "::set-env name=CXX::g++-8"
     - name: CMake build
-      run: cmake -Bbuild -DCMAKE_BUILD_TYPE=Release . && cd build && cmake --build . && cd Release && ./cppm build install
+      run: cmake -Bbuild -DCMAKE_BUILD_TYPE=Release -DUSE_CPPM_PATH=ON . && cd build && cmake --build . --target install --target cppm_link 
   ubuntu-xenial-llvm-8:
     runs-on: ubuntu-16.04
     steps:
@@ -39,5 +39,5 @@ jobs:
         echo "::set-env name=CC::clang-8"
         echo "::set-env name=CXX::clang++-8"
     - name: CMake build
-      run: cmake -Bbuild -DCMAKE_BUILD_TYPE=Release . && cd build && cmake --build . && cd Release && ./cppm build install
+      run: cmake -Bbuild -DCMAKE_BUILD_TYPE=Release -DUSE_CPPM_PATH=ON . && cd build && cmake --build . --target install --target cppm_link 
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -39,5 +39,5 @@ jobs:
         echo "::set-env name=CC::clang-8"
         echo "::set-env name=CXX::clang++-8"
     - name: CMake build
-      run: cmake -Bbuild . && cd build && cmake --build . --target install --target cppm_link 
+      run: cmake -Bbuild . && cd build && cmake --build && cd Release && ./cppm build install
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -20,7 +20,7 @@ jobs:
         echo "::set-env name=CC::gcc-8"
         echo "::set-env name=CXX::g++-8"
     - name: CMake build
-      run: cmake -Bbuild . && cd build && cmake --build .
+      run: cmake -Bbuild -DCMAKE_BUILD_TYPE=Release . && cd build && cmake --build && cd Release && ./cppm build install
   ubuntu-xenial-llvm-8:
     runs-on: ubuntu-16.04
     steps:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -39,5 +39,5 @@ jobs:
         echo "::set-env name=CC::clang-8"
         echo "::set-env name=CXX::clang++-8"
     - name: CMake build
-      run: cmake -Bbuild . && cd build && cmake --build && cd Release && ./cppm build install
+      run: cmake -Bbuild -DCMAKE_BUILD_TYPE=Release . && cd build && cmake --build && cd Release && ./cppm build install
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -39,5 +39,5 @@ jobs:
         echo "::set-env name=CC::clang-8"
         echo "::set-env name=CXX::clang++-8"
     - name: CMake build
-      run: cmake -Bbuild . && cd build && cmake --build . 
+      run: cmake -Bbuild . && cd build && cmake --build . --target install --target cppm_link 
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -20,7 +20,7 @@ jobs:
         echo "::set-env name=CC::gcc-8"
         echo "::set-env name=CXX::g++-8"
     - name: CMake build
-      run: cmake -Bbuild -DCMAKE_BUILD_TYPE=Release . && cd build && cmake --build && cd Release && ./cppm build install
+      run: cmake -Bbuild -DCMAKE_BUILD_TYPE=Release . && cd build && cmake --build . && cd Release && ./cppm build install
   ubuntu-xenial-llvm-8:
     runs-on: ubuntu-16.04
     steps:
@@ -39,5 +39,5 @@ jobs:
         echo "::set-env name=CC::clang-8"
         echo "::set-env name=CXX::clang++-8"
     - name: CMake build
-      run: cmake -Bbuild -DCMAKE_BUILD_TYPE=Release . && cd build && cmake --build && cd Release && ./cppm build install
+      run: cmake -Bbuild -DCMAKE_BUILD_TYPE=Release . && cd build && cmake --build . && cd Release && ./cppm build install
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -18,7 +18,7 @@ jobs:
         echo "::set-env name=CC::clang"
         echo "::set-env name=CXX::clang++"
     - name: CMake build
-      run: CC=/usr/local/opt/llvm/bin/clang CXX=/usr/local/opt/llvm/bin/clang++ cmake -Bbuild . && cd build && cmake --build . 
+      run: CC=/usr/local/opt/llvm/bin/clang CXX=/usr/local/opt/llvm/bin/clang++ cmake -Bbuild -DCMAKE_BUILD_TYPE=Release . && cd build && cmake --build . --target install --target cppm_link
 
 
   #  runs-on: macos-latest

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -18,7 +18,7 @@ jobs:
         echo "::set-env name=CC::clang"
         echo "::set-env name=CXX::clang++"
     - name: CMake build
-      run: CC=/usr/local/opt/llvm/bin/clang CXX=/usr/local/opt/llvm/bin/clang++ cmake -Bbuild -DCMAKE_BUILD_TYPE=Release . && cd build && cmake --build . --target install --target cppm_link
+      run: CC=/usr/local/opt/llvm/bin/clang CXX=/usr/local/opt/llvm/bin/clang++ cmake -Bbuild -DCMAKE_BUILD_TYPE=Release -DUSE_CPPM_PATH=ON . && cd build && cmake --build . --target install --target cppm_link
 
 
   #  runs-on: macos-latest

--- a/.github/workflows/window.yml
+++ b/.github/workflows/window.yml
@@ -15,9 +15,9 @@ jobs:
         submodules: true
     - name: CMake build
       run: |
-        cmake -Bbuild -DCMAKE_BUILD_TYPE=${{matrix.build-type}} .
+        cmake -Bbuild -DCMAKE_BUILD_TYPE=${{matrix.build-type}} -DUSE_CPPM_PATH=ON . 
         cd build
-        cmake --build . --config ${{matrix.build-type}}
+        cmake --build . --config ${{matrix.build-type}} --target install --target cppm_link
     - name: Cppm build install
       run: |
         cd build/${{matrix.build-type}}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if(NOT IS_CPPM_LOADED)
 endif()
 cppm_project()
 
-project(cppm VERSION 0.0.10 LANGUAGES C CXX)
+project(cppm VERSION 0.0.11 LANGUAGES C CXX)
 cppm_setting()
 cppm_cxx_standard(17)
 cppm_compiler_option(DEFAULT)
@@ -19,6 +19,11 @@ find_cppkg(tomlpp 0.6.0 MODULE tomlpp LOADPATH libs/tomlpp)
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
 find_cppkg(Catch2 2.9.1 MODULE Catch2::Catch2)
+endif()
+
+triplet_check("x64-unix")
+if(_result)
+find_cppkg(ctre 2.8.1 MODULE ctre::ctre)
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,11 +118,6 @@ set(global_deps PUBLIC fmt hashpp nlpo range-v3 tomlpp)
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
    list(APPEND global_deps PUBLIC Catch2)
 endif()
-
-triplet_check("unix")
-if(_result)
-list(APPEND global_deps PUBLIC dbg-macro)
-endif()
 cppm_target_dependencies(cppm-core
    ${global_deps})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,14 +11,14 @@ cppm_cxx_standard(17)
 cppm_compiler_option(DEFAULT)
 
 include(cmake/cppm_install.cmake)
-find_cppkg(fmt 6.2.0 MODULE fmt::fmt)
-find_cppkg(hashpp git MODULE hashpp::hashpp)
-find_cppkg(nlpo 1.0.3 MODULE nlpo LOADPATH libs/nlpo)
-find_cppkg(range-v3 git MODULE range-v3::range-v3)
-find_cppkg(tomlpp 0.6.0 MODULE tomlpp LOADPATH libs/tomlpp)
+find_cppkg(fmt 6.2.0  MODULE fmt::fmt TYPE lib)
+find_cppkg(hashpp git  MODULE hashpp::hashpp TYPE lib)
+find_cppkg(nlpo 1.0.3  MODULE nlpo LOADPATH libs/nlpo TYPE lib)
+find_cppkg(range-v3 git  MODULE range-v3::range-v3 TYPE lib)
+find_cppkg(tomlpp 0.6.0  MODULE tomlpp LOADPATH libs/tomlpp TYPE lib)
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-find_cppkg(Catch2 2.9.1 MODULE Catch2::Catch2)
+find_cppkg(Catch2 2.9.1  MODULE Catch2::Catch2 TYPE lib)
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,11 +21,6 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug")
 find_cppkg(Catch2 2.9.1 MODULE Catch2::Catch2)
 endif()
 
-triplet_check("unix")
-if(_result)
-find_cppkg(dbg-macro git MODULE dbg-macro::dbg-macro)
-endif()
-
 
 cppm_target_define(cppm-core STATIC
 SOURCES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,27 +31,6 @@ SOURCES
     src/util/algorithm.cpp
     src/util/system.cpp
     src/cppkg/cppkg.cpp
-    include/cppm/core/package.hpp
-    include/cppm/core/dependency.hpp
-    include/cppm/core/hunter.hpp
-    include/cppm/core/config.hpp
-    include/cppm/core/cppm_tool.hpp
-    include/cppm/core/target.hpp
-    include/cppm/core/cppkg.hpp
-    include/cppm/core/profile.hpp
-    include/cppm/core/config_interface.hpp
-    include/cppm/core/cmake.hpp
-    include/cppm/core/workspace.hpp
-    include/cppm/core/compiler.hpp
-    include/cppm/util/filesystem.h
-    include/cppm/util/hash.hpp
-    include/cppm/util/version.h
-    include/cppm/util/algorithm.hpp
-    include/cppm/util/system.hpp
-    include/cppm/util/optional.hpp
-    include/cppm/util/string.hpp
-    include/cppm/cppkg/repo.h
-    include/cppm/cppkg/cppkg.h
 )
 
 cppm_target_define(cppm BINARY

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,9 +21,9 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug")
 find_cppkg(Catch2 2.9.1 MODULE Catch2::Catch2)
 endif()
 
-triplet_check("x64-unix")
+triplet_check("unix")
 if(_result)
-find_cppkg(ctre 2.8.1 MODULE ctre::ctre)
+find_cppkg(dbg-macro git MODULE dbg-macro::dbg-macro)
 endif()
 
 
@@ -90,27 +90,6 @@ SOURCES
     src/util/algorithm.cpp
     src/util/system.cpp
     src/main.cpp
-    include/cppm/core/package.hpp
-    include/cppm/core/dependency.hpp
-    include/cppm/core/hunter.hpp
-    include/cppm/core/config.hpp
-    include/cppm/core/cppm_tool.hpp
-    include/cppm/core/target.hpp
-    include/cppm/core/cppkg.hpp
-    include/cppm/core/profile.hpp
-    include/cppm/core/config_interface.hpp
-    include/cppm/core/cmake.hpp
-    include/cppm/core/workspace.hpp
-    include/cppm/core/compiler.hpp
-    include/cppm/util/filesystem.h
-    include/cppm/util/hash.hpp
-    include/cppm/util/version.h
-    include/cppm/util/algorithm.hpp
-    include/cppm/util/system.hpp
-    include/cppm/util/optional.hpp
-    include/cppm/util/string.hpp
-    include/cppm/cppkg/repo.h
-    include/cppm/cppkg/cppkg.h
 )
 
 cppm_examples_area()
@@ -138,6 +117,11 @@ end_cppm_unit_test_area()
 set(global_deps PUBLIC fmt hashpp nlpo range-v3 tomlpp)
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
    list(APPEND global_deps PUBLIC Catch2)
+endif()
+
+triplet_check("unix")
+if(_result)
+list(APPEND global_deps PUBLIC dbg-macro)
 endif()
 cppm_target_dependencies(cppm-core
    ${global_deps})

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 
+
 [Cppm](https://injae.github.io/cppm/) ***(BETA)*** [Documents](https://injae.github.io/cppm/)
 ========
 |Linux|Windows|MacOS|
@@ -67,6 +68,11 @@ range-v3 = "git"
 
 [dev-dependencies]
     Catch2 = "2.9.1"
+
+#[target.x64-unix.dependencies]
+#[target.x64-unix.dev-dependencies]
+#[target.x64-windows.dependencies]
+#[target.windows.dev-dependencies]
 ```
 
 ## Easy to make Unregistered Package Add
@@ -138,7 +144,7 @@ cmake -Bbuild -DCMAKE_BUILD_TYPE=Release
 cd build
 cmake --build . --config Release
 cd Release && ./cppm build
-cd ../ && cmake --install .
+cd ../ && cmake --build . --target install --target cppm_link 
 # Add System Path %USERPROFILE%\.cppm\bin
 ```
 
@@ -146,15 +152,18 @@ cd ../ && cmake --install .
 - [x] easy configure file (cppm.toml)
 - [x] generate build command (cppm build {options})
 - [x] cmake dependencies auto installer (cppkg)
+- [x] none cppm base project build (cppm build) (with cppm-toolchain) command
 - [x] easy cppkg file generator (cppm cppkg init)
+- [x] auto add CMake project uninstall target (cppm build uninstall) (with cppm-toolchain)
 - [x] no sudo, package local install path (~/.cppm/)
+- [x] unit test option (cppm test)
 - [x] Cppkg package search (cppm search)
 - [x] cmake project initialize (cppm init {options} {name})
-- [x] cppkg repository update (cppm update)
+- [x] cppkg repository update (cppm cppkg update)
 - [x] hunter package dependency available 
-- [x] auto detect vcpkg 
+- [x] auto detect vcpkg
+- [x] can use hunter package manager 
 - [x] sub project option (cppm.toml [workspace])
-- [x] unit test option (cppm test)
 
 ## Document
 ### [GitBook](https://injae.github.io/cppm/)

--- a/README.md
+++ b/README.md
@@ -140,11 +140,9 @@ export PATH="$HOME/.cppm/bin:$PATH"
 # scoop install git cmake
 git clone --recurse-submodules https://github.com/injae/cppm.git
 cd cppm
-cmake -Bbuild -DCMAKE_BUILD_TYPE=Release
+cmake -Bbuild -DCMAKE_BUILD_TYPE=Release -DUSE_CPPM_PATH=ON
 cd build
-cmake --build . --config Release
-cd Release && ./cppm build
-cd ../ && cmake --build . --target install --target cppm_link 
+cmake --build . --config Release --target install --target cppm_link
 # Add System Path %USERPROFILE%\.cppm\bin
 ```
 

--- a/cmake/cppm_tool.cmake
+++ b/cmake/cppm_tool.cmake
@@ -4,12 +4,12 @@ else()
     set(env_home "$ENV{HOME}")
 endif()
 string(REPLACE "\\" "/" HOME "${env_home}")
-set(CPPM_VERSION "0.0.10")
+set(CPPM_TOOLS_VERSION "0.0.11")
 
 set(CPPM_ROOT   ${HOME}/.cppm)
 set(CPPM_CACHE  ${CPPM_ROOT}/cache)
 set(CPPM_PKGS   ${CPPM_ROOT}/cppkg)
-set(CPPM_CORE   ${CPPM_PKGS}/cppm-tools-${CPPM_VERSION})
+set(CPPM_CORE   ${CPPM_PKGS}/cppm-tools-${CPPM_TOOLS_VERSION})
 
 if(NOT DEFINED IS_CPPM_LOADED)
 set(_install_script "${CPPM_CACHE}/cppm-tools/${CPPM_VERSION}/install-script")
@@ -19,9 +19,9 @@ project(CPPM_TOOLS_DOWNLOAD NONE)
 include(ExternalProject)
 ExternalProject_Add(cppm-tools
     GIT_REPOSITORY https://github.com/injae/cppm_tools.git
-    GIT_TAG ${CPPM_VERSION}
+    GIT_TAG ${CPPM_TOOLS_VERSION}
     SOURCE_DIR ${CPPM_CORE}
-    BINARY_DIR ${CPPM_CACHE}/cppm-tools/${CPPM_VERSION}/build
+    BINARY_DIR ${CPPM_CACHE}/cppm-tools/${CPPM_TOOLS_VERSION}/build
     CONFIGURE_COMMAND \"\"
     BUILD_COMMAND  \"\"
     INSTALL_COMMAND \"\"

--- a/cppm.toml
+++ b/cppm.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "cppm"
-version = "0.0.10"
+version = "0.0.11"
 description = "c++ cmake maker use to toml like Cargo"
 git = "https://github.com/injae/cppm.git"
 
@@ -33,3 +33,6 @@ range-v3 = "git"
 
 [dev-dependencies]
     Catch2 = "2.9.1"
+
+[target.x64-unix.dependencies]
+    ctre = "2.8.1"

--- a/cppm.toml
+++ b/cppm.toml
@@ -13,7 +13,7 @@ source = ["src/core/.*", "src/util/.*", "src/cppkg/.*", "include/.*"]
 
 [[bin]]
 name   = "cppm"
-source = ["src/cmake/.*","src/option/.*", "src/util/.*", "src/main.cpp", "include/.*"]
+source = ["src/cmake/.*","src/option/.*", "src/util/.*", "src/main.cpp"]
 
 [[test]]
 name   = "cppm-test-check"
@@ -34,5 +34,5 @@ range-v3 = "git"
 [dev-dependencies]
     Catch2 = "2.9.1"
 
-[target.x64-unix.dependencies]
-    ctre = "2.8.1"
+[target.unix.dependencies]
+    dbg-macro = "git"

--- a/cppm.toml
+++ b/cppm.toml
@@ -34,5 +34,5 @@ range-v3 = "git"
 [dev-dependencies]
     Catch2 = "2.9.1"
 
-[target.unix.dependencies]
-    dbg-macro = "git"
+#[target.all-osx-clang.dependencies]
+#    dbg-macro = "git"

--- a/cppm.toml
+++ b/cppm.toml
@@ -9,7 +9,7 @@ include  = ["cmake/cppm_install.cmake"]
 
 [lib]
 name = "cppm-core"
-source = ["src/core/.*", "src/util/.*", "src/cppkg/.*", "include/.*"]
+source = ["src/core/.*", "src/util/.*", "src/cppkg/.*"]
 
 [[bin]]
 name   = "cppm"

--- a/docs/src/cppm_commands.md
+++ b/docs/src/cppm_commands.md
@@ -1,1 +1,6 @@
 # Cppm Commands
+- ***cppm build ***
+- ***cppm cppkg ***
+- ***cppm init ***
+- ***cppm test ***
+- ***cppm update ***

--- a/docs/src/cppm_guide.md
+++ b/docs/src/cppm_guide.md
@@ -1,4 +1,3 @@
 ## Cppm Guide
-
 * [cppm.toml](./cppm_toml.md)
 * [cppkg.toml](./cppkg_toml.md)

--- a/docs/src/cppm_structure.md
+++ b/docs/src/cppm_structure.md
@@ -1,7 +1,16 @@
 ## Cppm Structure
+cppm use cmake toolchain feature
+cppm build command use CMakeCache.txt 
+
+***cppm build*** command search cppm.toml or CMakeLists.txt
+```console
+$ cppm build --detail 
+cmake -DCMAKE_TOOLCHAIN_FILE=/path/to/.cppm/cppkg/cppm-tools-0.0.11/toolchain.cmake -DUSE_CPPM_PATH=ON -DCMAKE_BUILD_TYPE=Debug .. && cmake --build . --config Debug --  -j{your cpu core}
+```
+
 ~~~console
 ~/.cppm/
-├── bin  # cppm installed binary path
+├── bin  # cppm installed binary path (symbolic links)
 │   └── cppm # -> ../share/cppm-0.0.10/bin/cppm
 ├── cache ... # cmake build cache
 ├── cmake  # cppm module path
@@ -12,22 +21,18 @@
 │       ├── Catch2
 │       │   ├── 2.9.1
 │       │   │   ├── Catch2.cmake.in
-│       │   │   ├── cppkg.toml
-│       │   │   └── dep.cmake
+│       │   │   └── cppkg.toml
 │       │   └── git
 │       │       ├── Catch2.cmake.in
-│       │       ├── cppkg.toml
-│       │       └── dep.cmake
+│       │       └── cppkg.toml
 │       ├── cppm
 │       │   └── git
 │       .       ├── cppkg.toml
-│       .       ├── cppm.cmake.in
-│       .       └── dep.cmake
+│       .       └── cppm.cmake.in 
 └── cppkg  # cppkg install path
-    ├── cppm-0.0.10
+    ├── cppm-0.0.11
     .   ├── bin ...
     .   ├── include ...
-    .   ├── lib ...
-    .   └── src ...
+    .   └── lib ...
  
 ~~~

--- a/docs/src/cppm_toml.md
+++ b/docs/src/cppm_toml.md
@@ -96,20 +96,23 @@ Profile settings can be overridden for specific packages
 [target.{triplet}.dev-dependencies] 
 
 # triplet types
-# {arch}-{platform}-{generater}
+# {arch}-{platform}-{compiler}
 # arch
 # x86 or x64 or arm or arm64 or arm64s or arm7s or all(default)
 # platform
-# (       unix          )    (   windows  )
-# linux or osx or freebsd or uwp or windows
-# generator
-# make or ninja or msvc or xcode
+# (       unix                      )    (   windows  )
+# linux or osx or freebsd or android or uwp or windows
+# compiler
+# (        clang               )   
+# clang or clang_cl apple_clang or gnu(gcc) or msvc(cl) or intel or cuda(nvidia)
 
 ## example
 [target.x64-windows-msvc.dependencies]
+[target.all-windows-msvc.dependencies]
 [target.windows.dependencies]
 [target.unix.dependencies]
-[target.x64-macos-make.dependencies]
+[target.x64-macos-apple_clang.dependencies]
+[target.x64-macos-clang.dependencies]
 [target.macos.dependencies]
 [target.linux.dependencies]
 ```

--- a/docs/src/cppm_toml.md
+++ b/docs/src/cppm_toml.md
@@ -92,9 +92,26 @@ Profile settings can be overridden for specific packages
     #link.interface => this library use header only, dependency forward
 ```
 ```toml
-# (incomplete) platform classification depdencies setting 
-[target.windows|macos|linux|unix.dependencies] 
+[target.{triplet}.dependencies] 
+[target.{triplet}.dev-dependencies] 
 
+# triplet types
+# {arch}-{platform}-{generater}
+# arch
+# x86 or x64 or arm or arm64 or arm64s or arm7s or all(default)
+# platform
+# (       unix          )    (   windows  )
+# linux or osx or freebsd or uwp or windows
+# generator
+# make or ninja or msvc or xcode
+
+## example
+[target.x64-windows-msvc.dependencies]
+[target.windows.dependencies]
+[target.unix.dependencies]
+[target.x64-macos-make.dependencies]
+[target.macos.dependencies]
+[target.linux.dependencies]
 ```
 ```toml
 # (incomplete)

--- a/docs/src/install.md
+++ b/docs/src/install.md
@@ -27,11 +27,9 @@ export PATH=$PATH:$HOME/.cppm/bin
 # scoop install git cmake
 git clone --recurse-submodules https://github.com/injae/cppm.git
 cd cppm
-cmake -Bbuild -DCMAKE_BUILD_TYPE=Release
+cmake -Bbuild -DCMAKE_BUILD_TYPE=Release -DUSE_CPPM_PATH=ON
 cd build
-cmake --build . --config Release
-cd Release && ./cppm build
-cd ../ && cmake --build . --target install --target cppm_link 
+cmake --build . --config Release --target install --target cppm_link
 # Add System Path %USERPROFILE%\.cppm\bin
 ```
 

--- a/docs/src/install.md
+++ b/docs/src/install.md
@@ -23,15 +23,16 @@ export PATH=$PATH:$HOME/.cppm/bin
 
 #### Windows
 ```sh
-git clone https://github.com/injae/cppm
+# need visual studio , git , cmake
+# scoop install git cmake
+git clone --recurse-submodules https://github.com/injae/cppm.git
 cd cppm
-cmake -Bbuild -DCMAKE_BUILD_TYPE=Release.
+cmake -Bbuild -DCMAKE_BUILD_TYPE=Release
 cd build
 cmake --build . --config Release
-cd Release
-./cppm build install
-# Add Windows System Path %USERPROFILE%/.cppm/bin
+cd Release && ./cppm build
+cd ../ && cmake --build . --target install --target cppm_link 
+# Add System Path %USERPROFILE%\.cppm\bin
 ```
-
 
 

--- a/docs/src/introdution.md
+++ b/docs/src/introdution.md
@@ -10,6 +10,9 @@ upload to [cppkg](https://github.com/injae/cppkg)
 * Easy to use CMake 
 * Easy Config file than CMakeList.txt
 * Generate Cross Platform CMake base C++ Project
+* Dependencies auto install in build step
+* can use cmake uninstall target
+* CMake base project can build with cppm (cppm build) (Use CMake's toolchain feature)
 * Manage Depdendency with ***[cppkg](https://github.com/injae/cppkg)*** and ***[Hunter Package Manage](https://github.com/cpp-pm/hunter)***
 * Dependency install only use CMake
 

--- a/include/cppm/core/cmake.hpp
+++ b/include/cppm/core/cmake.hpp
@@ -14,7 +14,7 @@ namespace cppm::core {
                 .element(TOML_D(option))
                 .element(TOML_D(compiler))
                 .element(TOML_D(builder))
-                .element(TOML_D(toolchains))
+                .element(TOML_D(toolchain))
                 .element(TOML_D(include))
                 .no_remains();
         }
@@ -22,7 +22,7 @@ namespace cppm::core {
         opt<std::string> option;
         opt<std::string> compiler;
         opt<std::string> builder;
-        opt<arr<std::string>> toolchains;
+        opt<std::string> toolchain;
         opt<arr<std::string>> include;
     };
 }

--- a/include/cppm/core/dependency.hpp
+++ b/include/cppm/core/dependency.hpp
@@ -27,8 +27,8 @@ namespace cppm::core {
                 .element(TOML_D(custom), false)
                 .element(no_cmake, "no_module", false)
                 .element(TOML_D(components));
-            if(not defn.is_value() && *type == "lib") defn.element(TOML_D(module));
-            // defn.no_remains();
+            if(not defn.is_value() && *type == "lib") defn.element(TOML_D(module), "");
+            //defn.no_remains();
         }
 
         std::string name;

--- a/include/cppm/core/dependency.hpp
+++ b/include/cppm/core/dependency.hpp
@@ -19,6 +19,7 @@ namespace cppm::core {
                 .element(TOML_D(repo), "cppkg")
                 .element(TOML_D(path))
                 .element(TOML_D(url))
+                .element(TOML_D(sha256))
                 .element(TOML_D(git))
                 .element(TOML_D(flags))
                 .element(TOML_D(helper))
@@ -40,6 +41,7 @@ namespace cppm::core {
         opt<std::string> path;
         opt<std::string> git;
         opt<std::string> url;
+        opt<std::string> sha256;
         opt<std::string> helper;
         opt<std::string> branch;
         opt<std::string> flags;

--- a/include/cppm/core/dependency.hpp
+++ b/include/cppm/core/dependency.hpp
@@ -28,7 +28,7 @@ namespace cppm::core {
                 .element(no_cmake, "no_module", false)
                 .element(TOML_D(components));
             if(not defn.is_value() && *type == "lib") defn.element(TOML_D(module));
-            defn.no_remains();
+            // defn.no_remains();
         }
 
         std::string name;

--- a/include/cppm/core/target.hpp
+++ b/include/cppm/core/target.hpp
@@ -10,10 +10,12 @@ namespace cppm::core {
     public:
         template<typename Def>
         void parse(Def& defn) {
-           defn.element(TOML_D(dependencies))
-               .element(dev_dependencies,"dev-dependencies")
-               .no_remains();
+            defn.name();
+            defn.element(TOML_D(dependencies))
+                .element(dev_dependencies,"dev-dependencies")
+                .no_remains();
         }
+        std::string name;
         opt<nested<Dependency>> dependencies;
         opt<nested<Dependency>> dev_dependencies;
     };

--- a/src/cmake/cmake.h
+++ b/src/cmake/cmake.h
@@ -51,6 +51,7 @@ namespace cppm::cmake
         bool install=false;
         std::string prefix="";
         std::string build_type="Debug";
+        opt_str toolchain=std::nullopt;
         bool no_cache=false;
         bool sudo=false;
         bool detail=false;

--- a/src/core/cppm_tool.cpp
+++ b/src/core/cppm_tool.cpp
@@ -236,6 +236,20 @@ namespace cppm::core {
                                  , cmake::append("global_deps",grouped_deps(config.dev_dependencies)));
         }
 
+        if(config.target) {
+            ranges::for_each(*config.target, [&gen,&grouped_deps](auto& it) {
+                auto& [name, target] = it;
+                gen += "\ntriplet_check({})\nif(_result)\n"_format(cmake::quote(name));
+                gen += cmake::append("global_deps",grouped_deps(target.dependencies));
+                if (target.dev_dependencies) {
+                    gen += "\nif(CMAKE_BUILD_TYPE STREQUAL \"Debug\")\n";
+                    gen += cmake::append("global_deps",grouped_deps(target.dev_dependencies));
+                    gen += "endif()\n";
+                }
+                gen += "\nendif()\n";
+            });
+        }
+
         auto set_dependencies = [&config](auto& target) {
             std::vector<std::string> deps{cmake::getf("global_deps")};
             if(target.type != "lib" && config.lib) deps.emplace_back(config.lib->name);

--- a/src/core/cppm_tool.cpp
+++ b/src/core/cppm_tool.cpp
@@ -138,13 +138,14 @@ namespace cppm::core {
                 auto scripts = *deps | views::transform([](auto it) {
                     auto& [name, dep] = it;
                     auto hunter = dep.repo == "hunter" ? " HUNTER" : "";
-                    return fmt::format("find_cppkg({name} {ver} MODULE {module}{components}{path}{hunter})\n"
+                    return fmt::format("find_cppkg({name} {ver} {module}{components}{path}{hunter}{type})\n"
                                             ,"name"_a=dep.name
                                             ,"ver"_a=dep.version
-                                            ,"module"_a=dep.module
+                                            ,"module"_a=arg("MODULE",dep.module)
                                             ,"components"_a=qarg("COMPONENTS",dep.components)
                                             ,"path"_a=arg("LOADPATH",dep.path)
-                                            ,"hunter"_a=hunter);
+                                            ,"hunter"_a=hunter
+                                            ,"type"_a=arg("TYPE",dep.type));
                 }) | to_vector;
                 gen += fmt::format("{}",fmt::join(scripts, ""));
             }
@@ -300,7 +301,6 @@ namespace cppm::core {
             "cmake_minimum_required(VERSION 3.6)\n"
             "project({name}-{version}-install C CXX)\n\n"
             "include(${{CMAKE_CURRENT_SOURCE_DIR}}/cmake/cppm_tool.cmake)\n"
-            "set(CMAKE_PREFIX_PATH ${{CMAKE_PREFIX_PATH}})\n"
             "download_package({name} {version} {url} CMAKE_ARGS "
             "${{CMAKE_ARGS}} {flags})\n\n",
             "name"_a = dep.name, "version"_a = (*dep.version),

--- a/src/cppm_version.h
+++ b/src/cppm_version.h
@@ -3,6 +3,6 @@
 #ifndef __CPPM_VERSION_H_
 #define __CPPM_VERSION_H_
 
-#define CPPM_VERSION "0.0.10"
+#define CPPM_VERSION "0.0.11"
 
 #endif

--- a/src/option/base_option.cpp
+++ b/src/option/base_option.cpp
@@ -4,10 +4,18 @@
 #include <fmt/format.h>
 
 namespace cppm::option {
-    bool base_option::config_load() {
+    bool base_option::config_load(bool panic) {
         fs::path start_position = (start_path_ == "") ? fs::current_path() : fs::path{start_path_};
         auto path = cppm::util::reverse_find_file(start_position, "cppm.toml");
-        if(!path) { fmt::print(stderr, "can't find cppm.toml"); exit(1); return false; }
+        if(!path) {
+            if(panic) {
+                fmt::print("can't find cppm.toml\n");
+                exit(1);
+            } else {
+                fmt::print("can't find cppm.toml\nbuild with cppm_toolchain\n");
+            }
+            return false;
+        }
         // 나중에 쓸예정 none cppm test
         config_ = core::Config::load(path->parent_path().string());
         return true;

--- a/src/option/base_option.h
+++ b/src/option/base_option.h
@@ -13,7 +13,7 @@ namespace cppm::option
     public:
         nlpo::App& app() { return app_; }
         virtual ~base_option() {}
-        bool config_load();
+        bool config_load(bool panic=true);
         void start_from(const std::string& path) { start_path_ = path; }
     protected:
         nlpo::App app_;

--- a/src/option/cppkg_init.cpp
+++ b/src/option/cppkg_init.cpp
@@ -19,12 +19,12 @@ namespace cppm::option
                 if(std::regex_match(arg, match, is_url)) {
                     pkg.version = match[1];
                     pkg.url = arg;
-                    fmt::print("[cppkg] detect url and {}", pkg.version);
+                    fmt::print("[cppkg] detect url and {}\n", pkg.version);
                 }
                 else if(std::regex_match(arg, match, is_git)) {
                     pkg.version = "git";
                     pkg.git = arg;
-                    fmt::print("[cppkg] detect git and {}", pkg.version);
+                    fmt::print("[cppkg] detect git and {}\n", pkg.version);
                 }
                 else {
                     fmt::print(stderr, "can't parse uri\n");
@@ -65,7 +65,7 @@ namespace cppm::option
                 else if(app_.args().size() < 1) { fmt::print(stderr, "need package name"); exit(1); }
                 pkg.name = app_.get_arg();
                 if(!pkg.type) pkg.type = "lib";
-                if(!pkg.module) {
+                if(!pkg.module && *pkg.type == "lib") {
                     fmt::print("[cppkg] can't find module value\n");
                     fmt::print("[cppkg] module name find mode on\n");
                     auto current_path = fs::current_path();

--- a/src/util/filesystem.cpp
+++ b/src/util/filesystem.cpp
@@ -74,8 +74,9 @@ namespace cppm::util
         if(!list) return std::nullopt; 
         for(const auto& file : *list) {
             if(file.path().filename() == file_name) return std::make_optional(file.path());
-            if(file.path().filename() == "/")       return std::nullopt;
+            if(file.path() == fs::current_path().root_path()) return std::nullopt;
         }
+        if(path == fs::current_path().root_path()) return std::nullopt;
         return reverse_find_file(path.parent_path(), file_name);
     }
 

--- a/thirdparty/Catch2/2.9.1/Catch2.cmake.in
+++ b/thirdparty/Catch2/2.9.1/Catch2.cmake.in
@@ -10,6 +10,5 @@ cmake_minimum_required(VERSION 3.6)
 project(Catch2-2.9.1-install C CXX)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/cppm_tool.cmake)
-set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH})
 download_package(Catch2 2.9.1  URL https://github.com/catchorg/Catch2/archive/v2.9.1.tar.gz CMAKE_ARGS ${CMAKE_ARGS} -DCATCH_BUILD_TESTING=OFF)
 

--- a/thirdparty/ccache/3.7.9/ccache.cmake.in
+++ b/thirdparty/ccache/3.7.9/ccache.cmake.in
@@ -7,8 +7,11 @@
 # - Install Path Options:
 #    LOCAL(default) GLOBAL 
 cmake_minimum_required(VERSION 3.6)
-project(hashpp-git-install C CXX)
+project(ccache-3.7.9-install)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/cppm_tool.cmake)
-download_package(hashpp git  GIT https://github.com/injae/hashpp.git CMAKE_ARGS ${CMAKE_ARGS} )
-
+cppm_download_package(ccache
+    VERSION 3.7.9
+    URL https://github.com/ccache/ccache/releases/download/v3.7.9/ccache-3.7.9.tar.gz
+    INSTALL_SCRIPT "./configure --prefix=${CPPM_ROOT}/bin && make install"
+)

--- a/thirdparty/ccache/3.7.9/cppkg.toml
+++ b/thirdparty/ccache/3.7.9/cppkg.toml
@@ -1,0 +1,9 @@
+[ccache]
+version="3.7.9" #(require)
+type="bin" #lib(default) | bin | cmake
+description="" #(require)
+module="none"
+url="https://github.com/ccache/ccache/releases/download/v3.7.9/ccache-3.7.9.tar.gz" #(require)
+custom =true
+#branch="" #(optional & require git)
+#link="public" #default

--- a/thirdparty/ctre/2.8.1/ctre.cmake.in
+++ b/thirdparty/ctre/2.8.1/ctre.cmake.in
@@ -10,5 +10,6 @@ cmake_minimum_required(VERSION 3.6)
 project(ctre-2.8.1-install C CXX)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/cppm_tool.cmake)
+set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH})
 download_package(ctre 2.8.1  URL https://github.com/hanickadot/compile-time-regular-expressions/archive/v2.8.1.tar.gz CMAKE_ARGS ${CMAKE_ARGS} )
 

--- a/thirdparty/dbg-macro/git/cppkg.toml
+++ b/thirdparty/dbg-macro/git/cppkg.toml
@@ -1,17 +1,3 @@
-[package]
-name = "dbg-macro"
-# if you use git repo, package version is git
-version = "git"
-description = "Forked: A dbg(…) macro for C++"
-global=false
-# library name in cmake, cppm.toml use this value 
-# [dependencies]
-#${library_name} = {module =${value}}
-cmake = {name = "dbg-macro::dbg-macro", findlib=""}
-# write download value git or url
-download = {git="https://github.com/injae/dbg-macro.git"}
-#download = {url=""}
-
 [dbg-macro]
 version = "git"
 description = "Forked: A dbg(…) macro for C++"

--- a/thirdparty/dbg-macro/git/dbg-macro.cmake.in
+++ b/thirdparty/dbg-macro/git/dbg-macro.cmake.in
@@ -1,9 +1,4 @@
-cmake_minimum_required(VERSION 3.6)
-project(dbg-macro-git-install C CXX)
-
-include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/cppm_tool.cmake)
-download_package(dbg-macro git GIT https://github.com/injae/dbg-macro.git   LOCAL)
-
+# Cppkg Base Dependency Downloader
 # Other Options:
 # - Linux Configures:
 #    L_CONFIGURE {...}, L_BUILD {...}, L_INSTALL {...}
@@ -11,3 +6,10 @@ download_package(dbg-macro git GIT https://github.com/injae/dbg-macro.git   LOCA
 #    W_CONFIGURE {...}, W_BUILD {...}, W_INSTALL {...}
 # - Install Path Options:
 #    LOCAL(default) GLOBAL 
+cmake_minimum_required(VERSION 3.6)
+project(dbg-macro-git-install C CXX)
+
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/cppm_tool.cmake)
+set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH})
+download_package(dbg-macro git  GIT https://github.com/injae/dbg-macro.git CMAKE_ARGS ${CMAKE_ARGS} )
+

--- a/thirdparty/fmt/6.2.0/fmt.cmake.in
+++ b/thirdparty/fmt/6.2.0/fmt.cmake.in
@@ -10,6 +10,5 @@ cmake_minimum_required(VERSION 3.6)
 project(fmt-6.2.0-install C CXX)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/cppm_tool.cmake)
-set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH})
 download_package(fmt 6.2.0  URL https://github.com/fmtlib/fmt/releases/download/6.2.0/fmt-6.2.0.zip CMAKE_ARGS ${CMAKE_ARGS} -DFMT_DOC=OFF -DFMT_TEST=OFF -DFMT_FUZZ=OFF)
 

--- a/thirdparty/range-v3/git/range-v3.cmake.in
+++ b/thirdparty/range-v3/git/range-v3.cmake.in
@@ -10,6 +10,5 @@ cmake_minimum_required(VERSION 3.6)
 project(range-v3-git-install C CXX)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/cppm_tool.cmake)
-set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH})
 download_package(range-v3 git  GIT https://github.com/ericniebler/range-v3.git CMAKE_ARGS ${CMAKE_ARGS} -DRANGE_V3_TESTS=OFF -DRANGE_V3_EXAMPLES=OFF -DRANGE_V3_PERF=OFF -DRANGE_V3_HEADER_CHECKS=OFF)
 


### PR DESCRIPTION
cppm version 0.0.10 -> 0.0.11

cppm.toml

[target] config now can use

now bin type dependency can use
cppm_tools structure changed 
now cppm build command can build none cppm base cmake project
cppm now use cmake toolchain fand CMAKE_PACKAGE_INCLUDE feature
if you can build cmake project to use cppm build comand 
auto add uninstall target
